### PR TITLE
Updated mirrors of intelij (results from PR #934 review)

### DIFF
--- a/intellij/urls
+++ b/intellij/urls
@@ -1,3 +1,1 @@
 https://download-cf.jetbrains.com/idea/ideaI${edition}-${version}.${os}${ext}
-https://mirror.math.princeton.edu/idea/ideaI${edition}-${version}.${os}${ext}
-https://ftp.osuosl.org/idea/ideaI${edition}-${version}.${os}${ext}


### PR DESCRIPTION
Related to comment regarding intelij in PR #934 of the devonfw/ide repository. 
The two removed mirrors aren't working anymore.
